### PR TITLE
point to new group pages

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -76,10 +76,10 @@
 			<span class="ribbon"><b><a href="https://www.w3.org/Privacy/IG/">Privacy Interest Group (PING)</a></b></span>
 		  </h3>
 		  <ul class="theme">
-			<li><a href="https://www.w3.org/2019/09/privacy-ig-charter.html">Charter</a></li>
-			<li><a href="https://www.w3.org/2004/01/pp-impl/52497/join">Join (W3C members)</a></li>
-			<li><a href="https://www.w3.org/ieapp/new">Join (non-W3C-members)</a></li>
-			<li><a href="https://www.w3.org/2000/09/dbwg/details?group=52497&public=1">Participants</a></li>
+			<li><a href="https://www.w3.org/groups/ig/privacy/charters">Charter</a></li>
+			<li><a href="https://www.w3.org/groups/ig/privacy/join">Join (W3C members)</a></li>
+			<li><a href="https://www.w3.org/groups/ig/privacy/apply-as-invited-expert">Join (non-W3C-members)</a></li>
+			<li><a href="https://www.w3.org/groups/ig/privacy/participants">Participants</a></li>
 			<li><a href="http://lists.w3.org/Archives/Public/public-privacy/">Mailing list archive</a></li>
 			<li><a href="https://w3cping.slack.com/">Slack</a></li>
 			<li><a href="https://github.com/w3cping/tracking-issues/issues">Tracking issues</a>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -80,7 +80,7 @@
 			<li><a href="https://www.w3.org/groups/ig/privacy/join">Join (W3C members)</a></li>
 			<li><a href="https://www.w3.org/groups/ig/privacy/apply-as-invited-expert">Join (non-W3C-members)</a></li>
 			<li><a href="https://www.w3.org/groups/ig/privacy/participants">Participants</a></li>
-			<li><a href="http://lists.w3.org/Archives/Public/public-privacy/">Mailing list archive</a></li>
+			<li><a href="https://lists.w3.org/Archives/Public/public-privacy/">Mailing list archive</a></li>
 			<li><a href="https://w3cping.slack.com/">Slack</a></li>
 			<li><a href="https://github.com/w3cping/tracking-issues/issues">Tracking issues</a>
 			<li><a href="https://w3c.github.io/horizontal-issue-tracker/?repo=w3cping/tracking-issues">Tracker dashboard</a>

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ See [The Guide: How to get horizontal review](https://www.w3.org/Guide/documentr
 
 ## Joining PING
 
-Use the links in the sidebar.  If you're new to W3C, first [create a W3C account](http://cgi.w3.org/MemberAccess/AccessRequest).  Non-members of W3C may then join the IG as [public Invited Experts](http://www.w3.org/2004/08/invexp).  Please also join our [Slack](https://w3cping.slack.com/) -- email one of the W3C team (weiler or wseltzer) to request an invitation.
+Use the links in the sidebar.  If you're new to W3C, first [create a W3C account](http://cgi.w3.org/MemberAccess/AccessRequest).  Non-members of W3C may then join the IG as [public Invited Experts](https://www.w3.org/groups/ig/privacy/apply-as-invited-expert).  Please also join our [Slack](https://w3cping.slack.com/) -- email one of the W3C team (weiler or wseltzer) to request an invitation.
 
 ## Meeting Information
 


### PR DESCRIPTION
old links were being redirected, and the Invited Expert link was redirected to a useless place.